### PR TITLE
Feature/query to arrow table

### DIFF
--- a/src/tentaclio_databricks/clients/databricks_client.py
+++ b/src/tentaclio_databricks/clients/databricks_client.py
@@ -1,5 +1,6 @@
 """Databricks query client."""
 import pandas as pd
+import pyarrow as pa
 from databricks import sql
 from databricks.sql.types import Row
 from tentaclio import URL
@@ -61,3 +62,8 @@ class DatabricksClient:
         data = self.query(sql_query, **kwargs)
         columns = [col_desc[0] for col_desc in self.cursor.description]
         return pd.DataFrame(data, columns=columns)
+    
+    def get_arrow_table(self, sql_query: str, **kwargs) -> pa.Table:
+        """Run a raw SQL query and return a `pyarrow.Table`."""
+        self.cursor.execute(sql_query, **kwargs)
+        return self.cursor.fetchall_arrow()

--- a/src/tentaclio_databricks/clients/databricks_client.py
+++ b/src/tentaclio_databricks/clients/databricks_client.py
@@ -1,8 +1,7 @@
 """Databricks query client."""
-from typing import List
-
 import pandas as pd
 from databricks import sql
+from databricks.sql.types import Row
 from tentaclio import URL
 
 
@@ -48,7 +47,7 @@ class DatabricksClient:
         self.conn.close()
         self.cursor.close()
 
-    def query(self, sql_query: str, **kwargs) -> List[tuple]:
+    def query(self, sql_query: str, **kwargs) -> list[Row]:
         """Execute a SQL query, and return results."""
         self.cursor.execute(sql_query, **kwargs)
         return self.cursor.fetchall()

--- a/src/tentaclio_databricks/clients/databricks_client.py
+++ b/src/tentaclio_databricks/clients/databricks_client.py
@@ -14,7 +14,6 @@ class DatabricksClient:
     """Databricks client, backed by an Apache Thrift connection."""
 
     def __init__(self, url: URL, arraysize: int = 1000000, **kwargs):
-
         # This is a very common issue reported by the users
         if url.query is None or "HTTPPath" not in url.query:
             raise DatabricksClientException(
@@ -62,7 +61,7 @@ class DatabricksClient:
         data = self.query(sql_query, **kwargs)
         columns = [col_desc[0] for col_desc in self.cursor.description]
         return pd.DataFrame(data, columns=columns)
-    
+
     def get_arrow_table(self, sql_query: str, **kwargs) -> pa.Table:
         """Run a raw SQL query and return a `pyarrow.Table`."""
         self.cursor.execute(sql_query, **kwargs)

--- a/tests/unit/clients/test_databricks_client.py
+++ b/tests/unit/clients/test_databricks_client.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pyarrow as pa
 import pytest
 from tentaclio import URL
 
@@ -44,6 +45,16 @@ def test_get_df(mocker):
     client.cursor.description = [("id", "int", None)]
     df = client.get_df("foo")
     assert df.equals(expected)
+
+def test_get_arrow_table(mocker):
+    expected = pa.Table.from_pydict({"id": [1, 2, 3]})
+    url = "databricks+thrift://my_t0k3n@host.databricks.com?HTTPPath=/sql/1.0/endpoints/123456789"
+    client = DatabricksClient(URL(url))
+    client.cursor = mocker.MagicMock()
+    client.cursor.execute = lambda _: _
+    client.cursor.fetchall_arrow = lambda: pa.Table.from_pydict({"id": [1, 2, 3]})
+    table = client.get_arrow_table("foo")
+    assert table == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/clients/test_databricks_client.py
+++ b/tests/unit/clients/test_databricks_client.py
@@ -46,6 +46,7 @@ def test_get_df(mocker):
     df = client.get_df("foo")
     assert df.equals(expected)
 
+
 def test_get_arrow_table(mocker):
     expected = pa.Table.from_pydict({"id": [1, 2, 3]})
     url = "databricks+thrift://my_t0k3n@host.databricks.com?HTTPPath=/sql/1.0/endpoints/123456789"


### PR DESCRIPTION
## Description
`databricks.sql` allows queries to be fetched as `pyarrow.Table`s, which retain the exact data types as they exist in the datalake schema. These can then be easily converted to `pandas.DataFrame`s, retaining as much type information is possible when converting to Pandas/Numpy.

## Changes
- added `DatabricksClient.get_arrow_table()`
- this works basically the same as `DatabricksClient.get_df()` except:
    - it outputs a `pyarrow.Table`
    - it uses `cursor.fetchall_arrow()` interally (c.f. `cursor.fetchall()`)

## Changes -- rejected
- I've added an optional argument `format: Literal["python", "pandas", "pyarrow"]` to `DatabricksClient.query()` to allow the query result to be output in the desired format.
- The default is `format="python"` so that calls to `DatabricksClient.query()` with no `format` argument should return the same result as before the change.
- I've left `DatabricksClient.get_df()` unchanged so that there are no unexpected breakages due to change in type (c.f. using `query(..., format="pandas")` which will use `pyarrow.Table.to_pandas()` to fetch the `pandas.DataFrame`)