### PR TITLE
Fix release number to 2.1.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - 2026-07-30
+## [Unreleased]
+
+## [2.1.0] - 2026-07-30
 ### Changed
   - Bump the minimum supported Python from 3.9 (EOL) to 3.10. CircleCI executors bumped from
     `circleci/python:3.9` to `cimg/python:3.10` accordingly.


### PR DESCRIPTION
2.0.0 tag was used already:
https://github.com/octopus-energy/tentaclio-databricks/releases/tag/2.0.0